### PR TITLE
Adjust parameter bounds typing to allow None

### DIFF
--- a/ADSORFIT/app/client/controllers.py
+++ b/ADSORFIT/app/client/controllers.py
@@ -165,8 +165,8 @@ def load_dataset(file: Any) -> tuple[DatasetPayload | None, str]:
 def _build_parameter_bounds(
     metadata: list[ParameterKey],
     values: tuple[Any, ...],
-) -> dict[str, dict[str, dict[str, float]]]:
-    bounds: dict[str, dict[str, dict[str, float]]] = {}
+) -> dict[str, dict[str, dict[str, float | None]]]:
+    bounds: dict[str, dict[str, dict[str, float | None]]] = {}
     for (model, parameter, bound_type), raw_value in zip(metadata, values, strict=False):
         if model not in bounds:
             bounds[model] = {}


### PR DESCRIPTION
## Summary
- update the parameter bounds helper to return dictionaries that accept None values
- ensure solver configuration continues to consume the broader type without runtime changes

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e3d21d9c28832fad60151d687148fa